### PR TITLE
client repositioning

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,12 +10,11 @@ import json
 # from streamlit_elements import elements, mui
 from jd_analyzer import analyze_job_description, format_requirements_for_display, parse_edited_requirements
 from resume_analyzer import analyze_resume
-
 # Load environment variables
 load_dotenv()
 
+st.set_page_config(layout="wide")
 # Initialize OpenAI client
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 # Initialize session state for API key verification
 if 'api_key_verified' not in st.session_state:

--- a/jd_analyzer.py
+++ b/jd_analyzer.py
@@ -6,9 +6,6 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv()
 
-# Initialize OpenAI client
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-
 def analyze_job_description(job_description, model="gpt-4.1"):
     """
     Analyzes a job description using GPT-4 and extracts structured requirements.
@@ -18,6 +15,7 @@ def analyze_job_description(job_description, model="gpt-4.1"):
         job_description (str): The job description text to analyze
         model (str): The OpenAI model to use for analysis
     """
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     try:
         response = client.chat.completions.create(
             model=model,

--- a/resume_analyzer.py
+++ b/resume_analyzer.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Initialize OpenAI client
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
 
 def analyze_resume(resume_text, requirements, model="o4-mini"):
     """
@@ -23,21 +23,22 @@ def analyze_resume(resume_text, requirements, model="o4-mini"):
             - additional_screening_criteria
         model (str): The OpenAI model to use for analysis
     """
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     try:
         # Format the requirements for the prompt
         requirements_str = f"""
-Original Job Description:
-{requirements.get('original_job_description', '')}
+        Original Job Description:
+        {requirements.get('original_job_description', '')}
 
-Must-Have Requirements:
-{json.dumps(requirements.get('must_have_requirements', {}), indent=2)}
+        Must-Have Requirements:
+        {json.dumps(requirements.get('must_have_requirements', {}), indent=2)}
 
-Good-to-Have Requirements:
-{json.dumps(requirements.get('good_to_have_requirements', {}), indent=2)}
+        Good-to-Have Requirements:
+        {json.dumps(requirements.get('good_to_have_requirements', {}), indent=2)}
 
-Additional Screening Criteria:
-{json.dumps(requirements.get('additional_screening_criteria', []), indent=2)}
-"""
+        Additional Screening Criteria:
+        {json.dumps(requirements.get('additional_screening_criteria', []), indent=2)}
+        """
         
         response = client.chat.completions.create(
             model=model,


### PR DESCRIPTION
After cloning the project, I encountered an issue where I couldn’t set my API key via the browser app. This was due to a client variable being initialized at the module level in both jd_analyzer.py and resume_analyzer.py, which effectively overrides any API key set at runtime.

Fix: I moved the client initialization into the relevant function(s), ensuring it only gets created after the API key has been properly set. This allows the browser app to dynamically configure the key before use.